### PR TITLE
Add support for 'resign' and 'active' events

### DIFF
--- a/addon/services/ember-cordova/events.js
+++ b/addon/services/ember-cordova/events.js
@@ -20,6 +20,8 @@ const CORDOVA_EVENTS = new A([
   'deviceready',
   'pause',
   'resume',
+  'resign',
+  'active',
   'backbutton',
   'menubutton',
   'searchbutton',

--- a/tests/integration/events-test.js
+++ b/tests/integration/events-test.js
@@ -15,6 +15,8 @@ const CORDOVA_EVENTS = new A([
   'deviceready',
   'pause',
   'resume',
+  'resign',
+  'active',
   'backbutton',
   'menubutton',
   'searchbutton',


### PR DESCRIPTION
Adds support for the iOS specific events `resign` and `active`.

From the [Cordova documentation for `pause`](http://cordova.apache.org/docs/en/7.x/cordova/events/events.html#pause)

> The iOS-specific resign event is available as an alternative to pause, and detects when users enable the Lock button to lock the device with the app running in the foreground.

From the [Cordova documentation for `resume`](http://cordova.apache.org/docs/en/7.x/cordova/events/events.html#pause)

> The iOS-specific active event is available as an alternative to resume, and detects when users disable the Lock button to unlock the device with the app running in the foreground.