### PR TITLE
chore(ember): fix "new A()" deprecation warning

### DIFF
--- a/addon/services/ember-cordova/events.js
+++ b/addon/services/ember-cordova/events.js
@@ -16,7 +16,7 @@ const {
 } = Ember;
 
 // from https://cordova.apache.org/docs/en/4.0.0/cordova_events_events.md.html
-const CORDOVA_EVENTS = new A([
+const CORDOVA_EVENTS = A([
   'deviceready',
   'pause',
   'resume',


### PR DESCRIPTION
Ember has deprecated calling `A` as a constructor. 

https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_array-new-array-wrapper