### PR TITLE
feat: add on-cordova helper

### DIFF
--- a/addon/helpers/on-cordova.js
+++ b/addon/helpers/on-cordova.js
@@ -2,11 +2,11 @@ import Helper from "@ember/component/helper";
 import { inject as service } from "@ember/service";
 
 export function callbackWrapper(event, callback, bubbles) {
-  if (event.bubbles !== false) {
+  if (event.cancelBubble !== true) {
     let shouldBubble = callback(event);
 
     if (shouldBubble === false || bubbles === false) {
-      event.bubbles = false;
+      event.cancelBubble = true;
     }
 
     return shouldBubble;
@@ -14,7 +14,7 @@ export function callbackWrapper(event, callback, bubbles) {
 }
 
 export default Helper.extend({
-  cordovaEvents: service('ember-cordova/events'),
+  cordovaEvents: service("ember-cordova/events"),
 
   doFn(event) {
     return callbackWrapper(event, this.fn, this.bubbles);

--- a/addon/helpers/on-cordova.js
+++ b/addon/helpers/on-cordova.js
@@ -1,0 +1,37 @@
+import Helper from "@ember/component/helper";
+import { inject as service } from "@ember/service";
+
+export function callbackWrapper(event, callback, bubbles) {
+  if (event.bubbles !== false) {
+    let shouldBubble = callback(event);
+
+    if (shouldBubble === false || bubbles === false) {
+      event.bubbles = false;
+    }
+
+    return shouldBubble;
+  }
+}
+
+export default Helper.extend({
+  cordovaEvents: service('ember-cordova/events'),
+
+  doFn(event) {
+    return callbackWrapper(event, this.fn, this.bubbles);
+  },
+
+  compute([event, fn], { bubbles = true }) {
+    this.fn = fn;
+    this.event = event;
+    this.bubbles = bubbles;
+    //this.doFn = (event) => callbackWrapper(event, this.fn, this.bubbles);
+    this.cordovaEvents.on(event, this, "doFn");
+  },
+
+  willDestroy() {
+    if (this.fn && this.event) {
+      this.cordovaEvents.off(this.event, this, "doFn");
+    }
+    this._super.willDestroy();
+  },
+});

--- a/addon/helpers/on-cordova.js
+++ b/addon/helpers/on-cordova.js
@@ -32,6 +32,6 @@ export default Helper.extend({
     if (this.fn && this.event) {
       this.cordovaEvents.off(this.event, this, "doFn");
     }
-    this._super.willDestroy();
+    this._super(...arguments);
   },
 });

--- a/app/helpers/on-cordova.js
+++ b/app/helpers/on-cordova.js
@@ -1,0 +1,1 @@
+export { default, onCordova } from 'ember-cordova-events/helpers/on-cordova';

--- a/tests/dummy/app/components/on-cordova-component.js
+++ b/tests/dummy/app/components/on-cordova-component.js
@@ -1,0 +1,14 @@
+import Component from "@ember/component";
+import { inject as service } from "@ember/service";
+
+export default Component.extend({
+  cordovaEvents: service("ember-cordova/events"),
+  bubbles: true,
+
+  actions: {
+    yell() {
+      //eslint-disable-next-line
+      console.log(this.name);
+    },
+  },
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+	cordovaEvents: service('ember-cordova/events'),
+
+	currentEvent: 'backbutton',
+
+	actions: {
+		emitEvent() {
+			this.cordovaEvents.trigger(this.currentEvent, {});
+		}
+	}
+})

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,11 @@
-{{!-- The following component displays Ember's default welcome message. --}}
-{{welcome-page}}
-{{!-- Feel free to remove this! --}}
-
-{{outlet}}
+{{input value=(mut (get this "currentEvent"))}}
+<button {{action "emitEvent"}}>
+  Emit event
+</button>
+<div>
+  {{#on-cordova-component name="grandfather"}}
+    {{#on-cordova-component name="father"}}
+      {{#on-cordova-component name="child"}}{{/on-cordova-component}}
+    {{/on-cordova-component}}
+  {{/on-cordova-component}}
+</div>

--- a/tests/dummy/app/templates/components/on-cordova-component.hbs
+++ b/tests/dummy/app/templates/components/on-cordova-component.hbs
@@ -1,0 +1,23 @@
+<ul>
+  <li>
+    {{this.name}}
+    <button {{action (mut this.bubbles) (if this.bubbles false true)}}>
+      Bubbles:
+      {{if this.bubbles "true" "false"}}
+    </button>
+  </li>
+  {{on-cordova "backbutton" (action "yell") bubbles=this.bubbles}}
+  {{#if this.child}}
+    {{on-cordova-component name=(concat this.name "'s child")}}
+  {{/if}}
+  <button {{action (mut this.child) (if this.child false true)}}>
+    {{#if this.child}}
+      - Remove child for {{this.name}}
+    {{else}}
+      + Add child for {{this.name}}
+    {{/if}}
+  </button>
+		<br>
+		<br>
+  {{yield}}
+</ul>


### PR DESCRIPTION
Adds `{{on-cordova}}` helper for easier eventing on templates, this helper also implements the `bubbles=false`  that you would expect from normal dom events so effectively mimicking `stopPropatation()` because this helper works as a stack, it adds a handler when executed and stops bubbling if any invocation passed bubbles false.

A demo is included in the dummy app, just open the console to see the order of which the event is executed. the practical use case is opening modals on top of each other and wanting to close them in order, avoiding a supposed /routes/application.js history.back() default handler

![Screen Shot 2021-08-19 at 13 50 45](https://user-images.githubusercontent.com/9092644/130127205-fd278154-7443-4d12-90d7-a7d792ce7bb3.png)

By the way a capacitor version is here, based on this addon: [ember-capacitor-events](https://github.com/bengala-tech/ember-capacitor-events)

