### PR TITLE
Remove listeners the same way as adding them

### DIFF
--- a/addon/utils/subscribe.js
+++ b/addon/utils/subscribe.js
@@ -20,7 +20,7 @@ export default function subscribe(path, method) {
     // ensure teardown
     let _super = this.get('willDestroy');
     this.set('willDestroy', function() {
-      this.get(service).off(event, _listener);
+      this.get(service).off(event, this, _listener);
       _listener = null;
       computedFn = null;
       _super.call(this);


### PR DESCRIPTION
Fixes issue in ember testing where the listener was being destroyed before it being added